### PR TITLE
Enable to customize the names for temperature, etc, used in the MQTT message

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,6 @@ Copy or rename the `config.sample.ini` to `config.ini` in the `dbus-mqtt-tempera
 OR
 
 ```json
-{
-    "value": 22.0
-}
-```
-
-OR
-
-```json
 22.0
 ```
 
@@ -77,6 +69,7 @@ OR
 ```
 </details>
 
+You can customize the names used in the MQTT message in the config.
 
 ## Install / Update
 

--- a/dbus-mqtt-temperature/config.sample.ini
+++ b/dbus-mqtt-temperature/config.sample.ini
@@ -65,5 +65,20 @@ broker_port = 1883
 ;password = mypassword
 
 ; Topic where the temperature data as JSON string is published
-; minimum required JSON payload: {"temperature": 22.0 } or {"value": 22.0}
+; minimum required JSON payload: {"temperature": 22.0 }
 topic = N/aa00aa00aa00/battery/1/System/Temperature2
+
+; Temperature
+; Set the name for temperature in the MQTT message
+; default: temperature
+temperature_name = temperature
+
+; Humidity
+; Set the name for humidity in the MQTT message
+; default: humidity
+humidity_name = humidity
+
+; Pressure
+; Set the name for pressure in the MQTT message
+; default: pressure
+pressure_name = pressure

--- a/dbus-mqtt-temperature/dbus-mqtt-temperature.py
+++ b/dbus-mqtt-temperature/dbus-mqtt-temperature.py
@@ -74,6 +74,10 @@ if "DEFAULT" in config and "type" in config["DEFAULT"]:
 else:
     type = 2
 
+# get names used in the MQTT messages
+temperature_name = str(config["MQTT"]["temperature_name"])
+humidity_name = str(config["MQTT"]["humidity_name"])
+pressure_name = str(config["MQTT"]["pressure_name"])
 
 # set variables
 connected = 0
@@ -136,26 +140,23 @@ def on_message(client, userdata, msg):
 
                     last_changed = int(time())
 
-                    if "temperature" in jsonpayload or "value" in jsonpayload:
-                        if "temperature" in jsonpayload:
-                            temperature = float(jsonpayload["temperature"])
-                        elif "value" in jsonpayload:
-                            temperature = float(jsonpayload["value"])
+                    if temperature_name in jsonpayload:
+                        temperature = float(jsonpayload[temperature_name])
 
                         # check if humidity exists
-                        if "humidity" in jsonpayload:
-                            humidity = float(jsonpayload["humidity"])
+                        if humidity_name in jsonpayload:
+                            humidity = float(jsonpayload[humidity_name])
 
                         # check if pressure exists
-                        if "pressure" in jsonpayload:
-                            pressure = float(jsonpayload["pressure"])
+                        if pressure_name in jsonpayload:
+                            pressure = float(jsonpayload[pressure_name])
 
                     else:
-                        logging.error('Received JSON MQTT message does not include a temperature object. Expected at least: {"temperature": 22.0} or {"value": 22.0}')
+                        logging.error(f'Received JSON MQTT message does not include a temperature object. Expected at least: {{"{temperature_name}": 22.0}}')
                         logging.debug("MQTT payload: " + str(msg.payload)[1:])
 
             else:
-                logging.warning('Received JSON MQTT message was empty and therefore it was ignored. Expected at least: {"temperature": 22.0} or {"value": 22.0} or 22.0')
+                logging.warning(f'Received JSON MQTT message was empty and therefore it was ignored. Expected at least: {{"{temperature_name}": 22.0}} or 22.0')
                 logging.debug("MQTT payload: " + str(msg.payload)[1:])
 
     except TypeError as e:


### PR DESCRIPTION
I could not easily change the names that are used in the MQTT message. Thus I included further entries in the config to customize the names. If you think that could be helpful for other people as well, I would be happy to see these modifications in the main branch. 